### PR TITLE
Update version command and added get-config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,20 +20,19 @@ COPY ./utilities/ /builder/utilities/
 COPY ./cmd/ /builder/cmd/
 # building the linux and windows executable
 WORKDIR /builder/cli/
-RUN COMMIT_HASH="$(git rev-parse --short HEAD)"
+RUN COMMIT_HASH=$(git rev-parse --short HEAD)
 RUN BUILD_TIMESTAMP=$(date '+%Y-%m-%dT%H:%M:%S')
 RUN GO_VERSION=$(go version | awk {'print $3'})
 #RUN GIT_COMMIT=$(git rev-list -1 HEAD)
-ARG LDFLAGS = ( \
-    "-X '${PACKAGE}/version.MajorVersion=${MAJVERSION}'" \
-    "-X '${PACKAGE}/version.MinorVersion=${MINVERSION}'" \
-    "-X '${PACKAGE}/version.GitVersion=${GITVERSION}'" \
-    "-X '${PACKAGE}/version.GitHash=${COMMIT_HASH}'" \
-    "-X '${PACKAGE}/version.BuildDate=${BUILD_TIMESTAMP}'" \
-    "-X '${PACKAGE}/version.GoVersion=${GO_VERSION}'" \
-)
-RUN env GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="${LDFLAGS[*]}" -o /builder/output/kconnect-cli_linux-amd64_$GITVERSION
-RUN env GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="${LDFLAGS[*]}" -o /builder/output/kconnect-cli_win_amd64_$GITVERSION.exe
+ARG LDFLAGS="-X '$PACKAGE/version.MajorVersion=$MAJVERSION' \
+    -X '$PACKAGE/version.MinorVersion=$MINVERSION' \
+    -X '$PACKAGE/version.GitVersion=$GITVERSION' \
+    -X '$PACKAGE/version.GitHash=$COMMIT_HASH' \
+    -X '$PACKAGE/version.BuildDate=$BUILD_TIMESTAMP' \
+    -X '$PACKAGE/version.GoVersion=$GO_VERSION'"
+RUN echo $LDFLAGS # control statement TODELETE
+RUN env GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="$LDFLAGS" -o /builder/output/kconnect-cli_linux-amd64_$GITVERSION
+RUN env GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="$LDFLAGS" -o /builder/output/kconnect-cli_win_amd64_$GITVERSION.exe
 
 FROM scratch as artifact
 COPY --from=builder /builder/output/kconnect-cli* /build-output/

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,19 +31,7 @@ RUN echo -n " -X '$PACKAGE/version.GitHash=$(git rev-parse --short HEAD)'" >> fl
 RUN echo -n " -X '$PACKAGE/version.BuildDate=$(date '+%Y-%m-%dT%H:%M:%S')'" >> flags
 RUN echo -n " -X '$PACKAGE/version.GoVersion=$(go version | awk {'print $3'})'" >> flags
 
-#RUN export COMMIT_HASH=$(git rev-parse --short HEAD)
-#RUN echo $COMMIT_HASH
-#RUN export BUILD_TIMESTAMP=$(date '+%Y-%m-%dT%H:%M:%S')
-#RUN export GO_VERSION=$(go version | awk {'print $3'})
-#RUN GIT_COMMIT=$(git rev-list -1 HEAD)
-#ARG LDFLAGS="-X '$PACKAGE/version.MajorVersion=$MAJVERSION' \
-#    -X '$PACKAGE/version.MinorVersion=$MINVERSION' \
-#    -X '$PACKAGE/version.GitVersion=$GITVERSION' \
-#    -X '$PACKAGE/version.GitHash=$COMMIT_HASH' \
-#    -X '$PACKAGE/version.BuildDate=$BUILD_TIMESTAMP' \
-#    -X '$PACKAGE/version.GoVersion=$GO_VERSION'"
-# control statement TODELETE
-RUN cat flags 
+# run the build command with the flags created above
 RUN env GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="$(cat flags)" -o /builder/output/kconnect-cli_linux-amd64_$GITVERSION
 RUN env GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="$(cat flags)" -o /builder/output/kconnect-cli_win_amd64_$GITVERSION.exe
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ ARG GITVERSION
 ARG MAJVERSION=1
 ARG MINVERSION=0
 ARG PACKAGE=github.com/mattcolombo/kafka-connect-cli/cmd
+
 # creating the working directory, adding the module and sums file and installing the dependencies
 WORKDIR /builder 
 COPY ./go.mod /builder
@@ -20,6 +21,9 @@ COPY ./utilities/ /builder/utilities/
 COPY ./cmd/ /builder/cmd/
 # building the linux and windows executable
 WORKDIR /builder/cli/
+# installing git in the container so that I can find the hash
+RUN apk update && apk add git
+#get the information about git hash , build timestamp and go version
 RUN COMMIT_HASH=$(git rev-parse --short HEAD)
 RUN BUILD_TIMESTAMP=$(date '+%Y-%m-%dT%H:%M:%S')
 RUN GO_VERSION=$(go version | awk {'print $3'})

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,13 @@
 # adding an argument as the version, to add to the executables once built
-ARG CLIVERSION=v1.0.0
+ARG GITVERSION=v1.1.0
 
 # defining the build environment
 FROM golang:alpine AS builder 
 # refreshing ARG value for current image
-ARG CLIVERSION
+ARG GITVERSION
+ARG MAJVERSION=1
+ARG MINVERSION=0
+ARG PACKAGE=github.com/mattcolombo/kafka-connect-cli/cmd
 # creating the working directory, adding the module and sums file and installing the dependencies
 WORKDIR /builder 
 COPY ./go.mod /builder
@@ -17,8 +20,20 @@ COPY ./utilities/ /builder/utilities/
 COPY ./cmd/ /builder/cmd/
 # building the linux and windows executable
 WORKDIR /builder/cli/
-RUN env GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o /builder/output/kconnect-cli_linux-amd64_$CLIVERSION
-RUN env GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go build -o /builder/output/kconnect-cli_win_amd64_$CLIVERSION.exe
+RUN COMMIT_HASH="$(git rev-parse --short HEAD)"
+RUN BUILD_TIMESTAMP=$(date '+%Y-%m-%dT%H:%M:%S')
+RUN GO_VERSION=$(go version | awk {'print $3'})
+#RUN GIT_COMMIT=$(git rev-list -1 HEAD)
+ARG LDFLAGS = ( \
+    "-X '${PACKAGE}/version.MajorVersion=${MAJVERSION}'" \
+    "-X '${PACKAGE}/version.MinorVersion=${MINVERSION}'" \
+    "-X '${PACKAGE}/version.GitVersion=${GITVERSION}'" \
+    "-X '${PACKAGE}/version.GitHash=${COMMIT_HASH}'" \
+    "-X '${PACKAGE}/version.BuildDate=${BUILD_TIMESTAMP}'" \
+    "-X '${PACKAGE}/version.GoVersion=${GO_VERSION}'" \
+)
+RUN env GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="${LDFLAGS[*]}" -o /builder/output/kconnect-cli_linux-amd64_$GITVERSION
+RUN env GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="${LDFLAGS[*]}" -o /builder/output/kconnect-cli_win_amd64_$GITVERSION.exe
 
 FROM scratch as artifact
 COPY --from=builder /builder/output/kconnect-cli* /build-output/
@@ -26,7 +41,7 @@ COPY --from=builder /builder/output/kconnect-cli* /build-output/
 # building the actual useable image
 FROM ubuntu:22.04
 # refreshing ARG value for current image
-ARG CLIVERSION
+ARG GITVERSION
 # Installing jq for ease of management of JSON responses and vim to allow for managing files if required
 RUN apt update; apt install jq -y; apt install vim -y
 # Setting the working directory in the root and adding the script managing the sleep and the graceful exit if required
@@ -38,6 +53,6 @@ RUN chmod +x /background/stay_alive.sh
 CMD ["/background/stay_alive.sh"]
 # creating the working directory, adding the built executable from the previous step and adding the current workdir to the PATH
 WORKDIR /usr/cli
-COPY --from=builder /builder/output/kconnect-cli_linux-amd64_$CLIVERSION /usr/cli/kconnect-cli
+COPY --from=builder /builder/output/kconnect-cli_linux-amd64_$GITVERSION /usr/cli/kconnect-cli
 # adding the working directlry to the path, so that the CLI is accessible from any location
 ENV PATH="/usr/cli:${PATH}"

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The main commands to manage a connect cluster resource are as follow:
 * `connector` allows to gather information, create and manage connectors. Documentation on the usage of this resource can be found [here](/docs/CONNECTOR.md);
 * `task` allows to gather information and manage connector tasks. Documentation on the usage of this resource can be found [here](/docs/TASK.md);
 * `logger` allows to gather information and manage loggers and log levels. Documentation on the usage of this resource can be found [here](/docs/LOGGER.md);
-* `version` returns the current version of the CLI;
+* `version` returns the current version of the CLI. Using the flag `--json` (shorthand `-j`) will print the extended version in Json format;
 * `get-config` shows the path that the active CLI configuration file is being taken from, and prints out the full config file;
 * `help` provides help on the usage of the CLI. It can be used as a command or through the `--help` flag (shorthand `-h`).
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ The main commands to manage a connect cluster resource are as follow:
 * `connector` allows to gather information, create and manage connectors. Documentation on the usage of this resource can be found [here](/docs/CONNECTOR.md);
 * `task` allows to gather information and manage connector tasks. Documentation on the usage of this resource can be found [here](/docs/TASK.md);
 * `logger` allows to gather information and manage loggers and log levels. Documentation on the usage of this resource can be found [here](/docs/LOGGER.md);
-* `version` returns the current version of the CLI. If the `--show-cli-config` flag is added, will also provide information on the location of the currently used configuration file and the main URL and protocol of the Connect cluster in use;
+* `version` returns the current version of the CLI;
+* `get-config` shows the path that the active CLI configuration file is being taken from, and prints out the full config file;
 * `help` provides help on the usage of the CLI. It can be used as a command or through the `--help` flag (shorthand `-h`).
 
 ## Quickstart

--- a/cmd/getconfig/getconfig.go
+++ b/cmd/getconfig/getconfig.go
@@ -1,0 +1,19 @@
+package getconfig
+
+import (
+	"fmt"
+
+	"github.com/mattcolombo/kafka-connect-cli/utilities"
+	"github.com/spf13/cobra"
+)
+
+var GetConfigCmd = &cobra.Command{
+	Use:   "get-config",
+	Short: "shows details of the active CLI config file",
+	Long:  "shows the path of the currently active CLI config file and prints the config file",
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Printf("Config file (shown below) is currently loaded from path: %s\n", utilities.ConfigLoadPath)
+		fmt.Println("---")
+		utilities.PrettyPrintConfigYaml(utilities.ConnectConfiguration)
+	},
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/mattcolombo/kafka-connect-cli/cmd/cluster"
 	"github.com/mattcolombo/kafka-connect-cli/cmd/connector"
+	"github.com/mattcolombo/kafka-connect-cli/cmd/getconfig"
 	"github.com/mattcolombo/kafka-connect-cli/cmd/logger"
 	"github.com/mattcolombo/kafka-connect-cli/cmd/task"
 	"github.com/mattcolombo/kafka-connect-cli/cmd/version"
@@ -33,6 +34,7 @@ func init() {
 	rootCmd.AddCommand(task.TaskCmd)
 	rootCmd.AddCommand(logger.LoggerCmd)
 	rootCmd.AddCommand(version.VersionCmd)
+	rootCmd.AddCommand(getconfig.GetConfigCmd)
 
 	// disabled the default completion command as it is not going to be necessary
 	rootCmd.CompletionOptions.DisableDefaultCmd = true

--- a/cmd/version/version.go
+++ b/cmd/version/version.go
@@ -1,39 +1,46 @@
 package version
 
 import (
+	"encoding/json"
 	"fmt"
-	"strings"
+	"os"
 
 	"github.com/mattcolombo/kafka-connect-cli/utilities"
 	"github.com/spf13/cobra"
 )
 
-var showCliConfig bool
+var printJson bool
 
-var version = []byte(`{
-	"Major": "1", 
-	"Minor": "0", 
-	"GitVersion": "v1.0.0", 
-	"GitCommit": "manual_build"}`)
+var cliVersion = utilities.Version{
+	Major:      1,
+	Minor:      0,
+	GitVersion: "v1.0.1",
+	GitCommit:  "manual_build",
+}
 
 var VersionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "shows the CLI version and configuration used (if specified)",
 	Long:  "shows the CLI version and configuration used (if specified)",
 	Run: func(cmd *cobra.Command, args []string) {
-		utilities.PrettyPrintJson(version)
-		if showCliConfig {
-			printCliCfg()
+		if printJson {
+			byte, err := json.Marshal(&cliVersion)
+			if err != nil {
+				fmt.Println(err)
+				os.Exit(1)
+			}
+			utilities.PrettyPrintJson(byte)
+		} else {
+			printSimpleVersion()
 		}
 	},
 }
 
 func init() {
-	VersionCmd.Flags().BoolVarP(&showCliConfig, "show-cli-config", "", false, "prints the location and main URL for the configuration file being loaded")
+	VersionCmd.Flags().BoolVarP(&printJson, "json", "j", false, "prints the version information as Json")
 }
 
-func printCliCfg() {
-	fmt.Println("--- Current CLI Configuration ---")
-	fmt.Printf("Configuration for the CLI is being loaded from path: %s\n", utilities.ConfigLoadPath)
-	fmt.Printf("The main URL currently in use is <%s> with protocol %s\n", utilities.ConnectConfiguration.Hostnames[0], strings.ToUpper(utilities.ConnectConfiguration.Protocol))
+func printSimpleVersion() {
+	fmt.Println("GitVersion:", cliVersion.GitVersion)
+	fmt.Println("GitCommit:", cliVersion.GitCommit)
 }

--- a/cmd/version/version.go
+++ b/cmd/version/version.go
@@ -10,12 +10,20 @@ import (
 )
 
 var printJson bool
+var MajorVersion = "NA(manual_build)"
+var MinorVersion = "NA(manual_build)"
+var GitVersion = "NA(manual_build)"
+var GitHash = "NA(manual_build)"
+var BuildDate = "NA(manual_build)"
+var GoVersion = "NA(manual_build)"
 
 var cliVersion = utilities.Version{
-	Major:      1,
-	Minor:      0,
-	GitVersion: "v1.0.1",
-	GitCommit:  "manual_build",
+	Major:      MajorVersion,
+	Minor:      MinorVersion,
+	GitVersion: GitVersion,
+	GitCommit:  GitHash,
+	BuildDate:  BuildDate,
+	GoVersion:  GoVersion,
 }
 
 var VersionCmd = &cobra.Command{
@@ -41,6 +49,7 @@ func init() {
 }
 
 func printSimpleVersion() {
-	fmt.Println("GitVersion:", cliVersion.GitVersion)
-	fmt.Println("GitCommit:", cliVersion.GitCommit)
+	fmt.Println("Git Version:", cliVersion.GitVersion)
+	fmt.Println("Git Commit:", cliVersion.GitCommit)
+	fmt.Println("Build Date:", cliVersion.BuildDate)
 }

--- a/cmd/version/version.go
+++ b/cmd/version/version.go
@@ -20,8 +20,8 @@ var cliVersion = utilities.Version{
 
 var VersionCmd = &cobra.Command{
 	Use:   "version",
-	Short: "shows the CLI version and configuration used (if specified)",
-	Long:  "shows the CLI version and configuration used (if specified)",
+	Short: "shows the CLI version",
+	Long:  "shows the short CLI version; allows JSON extended print if specified",
 	Run: func(cmd *cobra.Command, args []string) {
 		if printJson {
 			byte, err := json.Marshal(&cliVersion)

--- a/utilities/printerUtilities.go
+++ b/utilities/printerUtilities.go
@@ -7,6 +7,8 @@ import (
 	"io"
 	"net/http"
 	"os"
+
+	"gopkg.in/yaml.v3"
 )
 
 func PrintEmptyBodyResponse(response *http.Response, successCode int, message string) {
@@ -35,6 +37,15 @@ func PrettyPrintJson(data []byte) {
 	var prettyData bytes.Buffer
 	json.Indent(&prettyData, data, "", "  ")
 	fmt.Println(prettyData.String())
+}
+
+func PrettyPrintConfigYaml(yamlData ConfigurationYaml) {
+	d, err := yaml.Marshal(&yamlData)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	fmt.Printf("%s", string(d))
 }
 
 func extractMessageFromJsonError(response *http.Response) string {

--- a/utilities/printerUtilities.go
+++ b/utilities/printerUtilities.go
@@ -40,12 +40,12 @@ func PrettyPrintJson(data []byte) {
 }
 
 func PrettyPrintConfigYaml(yamlData ConfigurationYaml) {
-	d, err := yaml.Marshal(&yamlData)
+	byte, err := yaml.Marshal(&yamlData)
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)
 	}
-	fmt.Printf("%s", string(d))
+	fmt.Printf("%s", string(byte))
 }
 
 func extractMessageFromJsonError(response *http.Response) string {

--- a/utilities/types.go
+++ b/utilities/types.go
@@ -39,8 +39,10 @@ type JsonError struct {
 }
 
 type Version struct {
-	Major      int    `json:"major"`
-	Minor      int    `json:"minor"`
+	Major      string `json:"major"`
+	Minor      string `json:"minor"`
 	GitVersion string `json:"gitVersion"`
 	GitCommit  string `json:"gitCommit"`
+	BuildDate  string `json:"buildDate"`
+	GoVersion  string `json:"goVersion"`
 }

--- a/utilities/types.go
+++ b/utilities/types.go
@@ -37,3 +37,10 @@ type JsonError struct {
 	Code    int    `json:"error_code"`
 	Message string `json:"message"`
 }
+
+type Version struct {
+	Major      int    `json:"major"`
+	Minor      int    `json:"minor"`
+	GitVersion string `json:"gitVersion"`
+	GitCommit  string `json:"gitCommit"`
+}


### PR DESCRIPTION
* Added the get-config command as a native command to get the config path and show the complete file
* Updated the version to show both simple and JSON version
* Added details about go version, build date, git commit and versioning automatically at build time (in the docker)