### PR TITLE
Added validation of task_id input

### DIFF
--- a/cmd/logger/get.go
+++ b/cmd/logger/get.go
@@ -17,7 +17,7 @@ var LoggerGetCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		pluginClass = args[0]
-		fmt.Println("pluiginClass is " + pluginClass) // control statement print
+		//fmt.Println("pluginClass is " + pluginClass) // control statement print
 		for _, host := range utilities.ConnectConfiguration.Hostnames {
 			var loggerListURL string = host + "/admin/loggers/" + pluginClass
 			fmt.Println("--- Getting Log Level for Connect worker at", host, "---")

--- a/cmd/task/get.go
+++ b/cmd/task/get.go
@@ -16,6 +16,7 @@ var TaskGetCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		connectorName = args[0]
 		taskID = args[1]
+		validateTaskIdInput(taskID)
 		var path string = "/connectors/" + connectorName + "/tasks/" + taskID + "/status"
 		//fmt.Println("making a call to", path) // control statement print
 		response, err := utilities.DoCallByPath(http.MethodGet, path, nil)

--- a/cmd/task/restart.go
+++ b/cmd/task/restart.go
@@ -16,6 +16,7 @@ var TaskRestartCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		connectorName = args[0]
 		taskID = args[1]
+		validateTaskIdInput(taskID)
 		var path string = "/connectors/" + connectorName + "/tasks/" + taskID + "/restart"
 		//fmt.Println("making a call to", path) // control statement print
 		response, err := utilities.DoCallByPath(http.MethodPost, path, nil)

--- a/cmd/task/task.go
+++ b/cmd/task/task.go
@@ -1,6 +1,10 @@
 package task
 
 import (
+	"fmt"
+	"os"
+	"strconv"
+
 	"github.com/spf13/cobra"
 )
 
@@ -17,4 +21,12 @@ func init() {
 	TaskCmd.AddCommand(TaskListCmd)
 	TaskCmd.AddCommand(TaskGetCmd)
 	TaskCmd.AddCommand(TaskRestartCmd)
+}
+
+func validateTaskIdInput(id string) {
+	_, err := strconv.ParseInt(id, 10, 64)
+	if err != nil {
+		fmt.Println("task_id must be a digit")
+		os.Exit(1)
+	}
 }


### PR DESCRIPTION
task_id must be a digit for the call to work. Since it is taken as an argument, and therefore is really a string, we need to manage the case where the string is not a digit. 

Validation is added so that the CLI will throw an error before making the call if the input is not a digit (aka if it cannot be converted to int).