### PR TITLE
Validation of log level to set

### DIFF
--- a/cmd/logger/set.go
+++ b/cmd/logger/set.go
@@ -3,30 +3,41 @@ package logger
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
+	"os"
+	"strings"
 
 	"github.com/mattcolombo/kafka-connect-cli/utilities"
 	"github.com/spf13/cobra"
 )
 
-var setLevel string
+var inSetLevel string
 var defaultLevel = "INFO" // TODO set this from the config file intstead than hardcoding
 
 var LoggerSetCmd = &cobra.Command{
 	Use:   "set [flags] logger_name",
 	Short: "sets the log level set for a logger",
 	Long: "Allows to set the log level set for a specific logger or connector plugin at runtime;" +
-		" allowed log levels are as in Java [\"OFF\",\"FATAL\",\"ERROR\",\"WARN\",\"INFO\",\"DEBUG\",\"TRACE\"]",
+		"\tallowed log levels are as in Java [\"OFF\",\"FATAL\",\"ERROR\",\"WARN\",\"INFO\",\"DEBUG\",\"TRACE\"]",
 	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		pluginClass = args[0]
+		setLevel := strings.ToUpper(inSetLevel)
+		fmt.Println("input set level is", inSetLevel)
+		fmt.Println("checked set level is", setLevel)
+		_, err := validateLogLevel(setLevel)
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
 		//fmt.Println("pluiginClass is " + pluginClass) // control statement print
 		for _, host := range utilities.ConnectConfiguration.Hostnames {
 			var loggerListURL string = host + "/admin/loggers/" + pluginClass
 			fmt.Println("--- Setting Log Level", setLevel, "for Connect worker at", host, "---")
 			//fmt.Println("making a call to", loggerListURL) // control statement print
-			response, err := utilities.DoCallByHost(http.MethodPut, loggerListURL, bytes.NewBuffer(buildSetPayload()))
+			response, err := utilities.DoCallByHost(http.MethodPut, loggerListURL, bytes.NewBuffer(buildSetPayload(setLevel)))
 			if err != nil {
 				fmt.Printf("The HTTP request failed with error %s\n", err)
 			} else {
@@ -37,13 +48,28 @@ var LoggerSetCmd = &cobra.Command{
 }
 
 func init() {
-	LoggerSetCmd.Flags().StringVarP(&setLevel, "level", "", defaultLevel, "log level to set")
+	LoggerSetCmd.Flags().StringVarP(&inSetLevel, "level", "", defaultLevel, "log level to set")
 }
 
-func buildSetPayload() []byte {
-	payload, err := json.Marshal(map[string]interface{}{"level": setLevel})
+func buildSetPayload(level string) []byte {
+	payload, err := json.Marshal(map[string]interface{}{"level": level})
 	if err != nil {
 		fmt.Printf("JSON build failed with error %s\n", err)
 	}
 	return payload
+}
+
+func validateLogLevel(level string) (bool, error) {
+	switch level {
+	case
+		"OFF",
+		"FATAL",
+		"ERROR",
+		"WARN",
+		"INFO",
+		"DEBUG",
+		"TRACE":
+		return true, nil
+	}
+	return false, errors.New("invalid log level; valid log levels are [\"OFF\",\"FATAL\",\"ERROR\",\"WARN\",\"INFO\",\"DEBUG\",\"TRACE\"]")
 }

--- a/docs/LOGGER.md
+++ b/docs/LOGGER.md
@@ -16,6 +16,6 @@ Further information on the use of the Connect API to control loggers at runtime 
 
 `kconnect-cli logger set`: requires the logger/plugin class name as first positional argument. The flag `--level` for the log level to set is available, if absent the command will act as a reset of sort and the level set will default to `INFO`. This flag allows to set the desired log level for the specified logger in each of the Connect workers present. This command uses the `PUT /admin/loggers/(string:logger_name)` endpoint for each of the hosts specified in the CLI configuration file.
 
-Allowed log levels are the usual Java/log4j levels which are (in increasing verbosity order) `OFF`, `FATAL`, `ERROR`, `WARN`, `INFO`, `DEBUG`, `TRACE`.
+Allowed log levels are the usual Java/log4j levels which are (in increasing verbosity order) `OFF`, `FATAL`, `ERROR`, `WARN`, `INFO`, `DEBUG`, `TRACE`. Note that in the input capitalisation is not important, eg. `--level ERROR` and `--level error` will produce the same result.
 
 **NOTE:** The log level set in this way is persisted only until the Connect worker gets restarted. Once the Connector worker restarts the log levels for all loggers revert back to the ones set in the Connect worker configuration.

--- a/docs/TASK.md
+++ b/docs/TASK.md
@@ -8,8 +8,8 @@ Allows to list, gather information and manage connector tasks.
 
 ## get
 
-`kconnect-cli task get`: requires the connector name as first positional argument and the task ID as second positional argument. Gathers information on the status of task `task_id` for connector `connector_name`. This command uses the `GET /connectors/(string:connector_name)/tasks/(int:taskID)/status`.
+`kconnect-cli task get`: requires the connector name as first positional argument and the task ID as second positional argument. The task ID must be a digit or an error will be thrown. Gathers information on the status of task `task_id` for connector `connector_name`. This command uses the `GET /connectors/(string:connector_name)/tasks/(int:taskID)/status`.
 
 ## restart
 
-`kconnect-cli task restart`: requires the connector name as first positional argument and the task ID as second positional argument. Restarts task `task_id` for connector `connector_name`. This command uses the `POST /connectors/(string:connector_name)/tasks/(int:taskID)/restart`.
+`kconnect-cli task restart`: requires the connector name as first positional argument and the task ID as second positional argument. The task ID must be a digit or an error will be thrown. Restarts task `task_id` for connector `connector_name`. This command uses the `POST /connectors/(string:connector_name)/tasks/(int:taskID)/restart`.


### PR DESCRIPTION
The log level cannot be set to values outside of the usual Java one. Validation is added to the CLI to manage the cases where a wrong input is passed before the call to Connect itself is made. This is done to avoid network issues and similar things.